### PR TITLE
DO-3381: Add GPG Key Setup for Atlantis ECS Task 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,9 @@ allow_github_webhooks        = true
 ## Notes
 
 1. AWS Route53 zone is not created by this module, so zone specified as a value in `route53_zone_name` should be created before using this module. Check documentation for [aws_route53_zone](https://www.terraform.io/docs/providers/aws/r/route53_zone.html).
-1. Currently this module configures Atlantis in a way that it can not be used to work with GitHub and Gitlab simultaneously (can't make list of ECS secrets conditionally).
-1. For Bitbucket Cloud webhook configuration follow instructions in [the official Atlantis documentation](https://www.runatlantis.io/docs/configuring-webhooks.html#bitbucket-cloud-bitbucket-org-webhook).
+2. Currently this module configures Atlantis in a way that it can not be used to work with GitHub and Gitlab simultaneously (can't make list of ECS secrets conditionally).
+3. For Bitbucket Cloud webhook configuration follow instructions in [the official Atlantis documentation](https://www.runatlantis.io/docs/configuring-webhooks.html#bitbucket-cloud-bitbucket-org-webhook).
+4. Added a gpg key ssm param and secret for task definition
 
 <!-- TODO: For Bitbucket Cloud an IP whitelist should be implemented for the webhook url as stated in [the official Atlantis documentation](https://www.runatlantis.io/docs/security.html#bitbucket-cloud-bitbucket-org) due to lack of support for webhook secrets. -->
 
@@ -315,6 +316,8 @@ allow_github_webhooks        = true
 | <a name="input_atlantis_github_app_id"></a> [atlantis\_github\_app\_id](#input\_atlantis\_github\_app\_id) | GitHub id of the app that is running the Atlantis command | `string` | `""` | no |
 | <a name="input_atlantis_github_app_key"></a> [atlantis\_github\_app\_key](#input\_atlantis\_github\_app\_key) | GitHub key pem of the app that is running the Atlantis command | `string` | `""` | no |
 | <a name="input_atlantis_github_app_key_ssm_parameter_name"></a> [atlantis\_github\_app\_key\_ssm\_parameter\_name](#input\_atlantis\_github\_app\_key\_ssm\_parameter\_name) | Name of SSM parameter to keep atlantis\_github\_app\_key | `string` | `"/atlantis/github/app/key"` | no |
+| <a name="input_atlantis_gpg_secret"></a> [atlantis\_gpg\_secret](#input\_atlantis\_gpg\_secret) | GPG Key for running git-crypt commands | `string` | `""` | no |
+| <a name="input_atlantis_gpg_ssm_parameter_name"></a> [atlantis\_gpg\ ssm\_parameter\_name](#input\_atlantis\_gpg\_ssm\_parameter\_name) | Name of SSM parameter to keep atlantis\_gpg\_key | `string` | `"/atlantis/gpg/key"` | no |
 | <a name="input_atlantis_github_user"></a> [atlantis\_github\_user](#input\_atlantis\_github\_user) | GitHub username that is running the Atlantis command | `string` | `""` | no |
 | <a name="input_atlantis_github_user_token"></a> [atlantis\_github\_user\_token](#input\_atlantis\_github\_user\_token) | GitHub token of the user that is running the Atlantis command | `string` | `""` | no |
 | <a name="input_atlantis_github_user_token_ssm_parameter_name"></a> [atlantis\_github\_user\_token\_ssm\_parameter\_name](#input\_atlantis\_github\_user\_token\_ssm\_parameter\_name) | Name of SSM parameter to keep atlantis\_github\_user\_token | `string` | `"/atlantis/github/user/token"` | no |

--- a/main.tf
+++ b/main.tf
@@ -198,6 +198,7 @@ resource "aws_ssm_parameter" "atlantis_gpg_key" {
   name  = var.atlantis_gpg_ssm_parameter_name
   type  = "SecureString"
   value = var.atlantis_gpg_secret
+  tier  = "Advanced"
 
   tags = local.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -109,6 +109,14 @@ locals {
     },
   ] : []
 
+  # GPG Key Secret
+  container_definition_secrets_3 = [
+    {
+      name      = "ATLANTIS_GPG_KEY"
+      valueFrom = var.atlantis_gpg_ssm_parameter_name
+    },
+  ]
+
   tags = merge(
     {
       "Name" = var.name
@@ -182,6 +190,14 @@ resource "aws_ssm_parameter" "atlantis_github_app_key" {
   name  = var.atlantis_github_app_key_ssm_parameter_name
   type  = "SecureString"
   value = var.atlantis_github_app_key
+
+  tags = local.tags
+}
+
+resource "aws_ssm_parameter" "atlantis_gpg_key" {
+  name  = var.atlantis_gpg_ssm_parameter_name
+  type  = "SecureString"
+  value = var.atlantis_gpg_secret
 
   tags = local.tags
 }
@@ -573,6 +589,7 @@ data "aws_iam_policy_document" "ecs_task_access_secrets" {
       aws_ssm_parameter.atlantis_gitlab_user_token.*.arn,
       aws_ssm_parameter.atlantis_bitbucket_user_token.*.arn,
       aws_ssm_parameter.atlantis_github_app_key.*.arn,
+      aws_ssm_parameter.atlantis_gpg_key.*.arn
     ])
 
     actions = [

--- a/main.tf
+++ b/main.tf
@@ -684,6 +684,7 @@ module "container_definition_github_gitlab" {
   secrets = concat(
     local.container_definition_secrets_1,
     local.container_definition_secrets_2,
+    local.container_definition_secrets_3,
     var.custom_environment_secrets,
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -268,6 +268,12 @@ variable "webhook_ssm_parameter_name" {
   default     = "/atlantis/webhook/secret"
 }
 
+variable "atlantis_gpg_ssm_parameter_name" {
+  description = "Name of SSM parameter to keep gpg key"
+  type        = string
+  default     = "/atlantis/gpg/secret"
+}
+
 variable "atlantis_github_user_token_ssm_parameter_name" {
   description = "Name of SSM parameter to keep atlantis_github_user_token"
   type        = string
@@ -584,6 +590,12 @@ variable "atlantis_github_user" {
 
 variable "atlantis_github_user_token" {
   description = "GitHub token of the user that is running the Atlantis command"
+  type        = string
+  default     = ""
+}
+
+variable "atlantis_gpg_secret" {
+  description = "GPG secret"
   type        = string
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -578,7 +578,7 @@ variable "atlantis_log_level" {
 variable "atlantis_hide_prev_plan_comments" {
   description = "Enables atlantis server --hide-prev-plan-comments hiding previous plan comments on update"
   type        = string
-  default     = "false"
+  default     = "true"
 }
 
 # Github


### PR DESCRIPTION
# Changes
- add ssm param and permission structure update to ECS task definition for Atlantis for GPG key

# Expected Behavior
- new ssm entry created for gpg key
- ECS task has access to pull secret string from ssm entry

# Jira Ticket
[DO-3381](https://fluenceenergy.atlassian.net/browse/DO-3381)

[DO-3381]: https://fluenceenergy.atlassian.net/browse/DO-3381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ